### PR TITLE
Add iOS 13 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ARCHS = armv7 armv7s arm64
+ARCHS = armv7 armv7s arm64 arm64e
 
 TARGET = iphone:clang:9.2:6.0
 

--- a/PFColorAlert.m
+++ b/PFColorAlert.m
@@ -1,6 +1,7 @@
 #import "PFColorAlert.h"
 #import "PFColorAlertViewController.h"
 #import "UIColor+PFColor.h"
+#import "UIKitAdditions.h"
 #import <objc/runtime.h>
 
 extern void LCPShowTwitterFollowAlert(NSString *title, NSString *welcomeMessage, NSString *twitterUsername);
@@ -12,7 +13,6 @@ extern void LCPShowTwitterFollowAlert(NSString *title, NSString *welcomeMessage,
 @property (nonatomic, assign) BOOL isOpen;
 @property (nonatomic, copy) void (^completionBlock)(UIColor *pickedColor);
 @end
-
 
 @implementation PFColorAlert
 
@@ -35,7 +35,14 @@ extern void LCPShowTwitterFollowAlert(NSString *title, NSString *welcomeMessage,
         winFrame.size.height = _width;
     }
 
-    self.darkeningWindow = [[UIWindow alloc] initWithFrame:winFrame];
+    if (@available(iOS 13, *)) {
+        NSSet<UIScene *> *connectedScenes = [[UIApplication sharedApplication] connectedScenes];
+        UIScene *firstScene = [[connectedScenes allObjects] objectAtIndex:0];
+        self.darkeningWindow = [[UIWindow alloc] initWithWindowScene: firstScene];
+        self.darkeningWindow.frame = winFrame;
+    } else {
+        self.darkeningWindow = [[UIWindow alloc] initWithFrame:winFrame];
+    }
     self.darkeningWindow.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.4f];
 
     float winWidthCalc = winFrame.size.width * 0.09f;
@@ -47,7 +54,14 @@ extern void LCPShowTwitterFollowAlert(NSString *title, NSString *welcomeMessage,
     winFrame.size.width = winFrame.size.width - winWidthCalc;
     winFrame.size.height = winFrame.size.height - winHeightCalc;
 
-    self.popWindow = [[UIWindow alloc] initWithFrame:winFrame];
+    if (@available(iOS 13, *)) {
+        NSSet<UIScene *> *connectedScenes = [[UIApplication sharedApplication] connectedScenes];
+        UIScene *firstScene = [[connectedScenes allObjects] objectAtIndex:0];
+        self.popWindow = [[UIWindow alloc] initWithWindowScene: firstScene];
+        self.popWindow.frame = winFrame;
+    } else {
+        self.popWindow = [[UIWindow alloc] initWithFrame:winFrame];
+    }
     self.popWindow.layer.masksToBounds = true;
     self.popWindow.layer.cornerRadius = 15;
 

--- a/UIKitAdditions.h
+++ b/UIKitAdditions.h
@@ -1,0 +1,14 @@
+@interface UIScene : NSObject
+@end
+
+@interface UIWindowScene
+@property (nonatomic, retain) NSSet<UIWindow *> *windows;
+@end
+
+@interface UIWindow (NewiOSMethods)
+-(instancetype) initWithWindowScene:(UIScene *)scene;
+@end
+
+@interface UIApplication (NewiOSMethods)
+-(id)connectedScenes;
+@end

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: org.thebigboss.libcolorpicker
 Name: libcolorpicker
 Depends: firmware (>= 6.0)
-Version: 1.6.4
+Version: 1.6.5
 Replaces: me.nepeta.libcolorpicker
 Provides: me.nepeta.libcolorpicker
 Architecture: iphoneos-arm


### PR DESCRIPTION
This commit adds minimal changes to allow the color picker window to appear on iOS 13. The reason this was broken was because of iOS's new way of handling UIWindow objects. (they seem to sometimes need a UIWindowScene object).